### PR TITLE
Fix: Render leading/trailing spaces in text and background

### DIFF
--- a/script.js
+++ b/script.js
@@ -1747,7 +1747,8 @@
             const drawLines = (drawFunc) => {
                 lines.forEach((line, index) => {
                     const currentY = yPos + (index * lineHeight);
-                    drawFunc(line.trim(), xPos, currentY);
+                    // Remove .trim() to render leading/trailing spaces
+                    drawFunc(line, xPos, currentY);
                 });
             };
 


### PR DESCRIPTION
Modified the `drawTextWithEffect` function in `script.js` to remove the `.trim()` call before drawing text. This ensures that any leading or trailing spaces in the text input fields are now visually rendered on the canvas and also contribute to the width of the text background if one is applied.

This addresses the requirement for spaces to act as padding for both the visual text and its background.