### PR TITLE
Fix: Resolve stylePresets error and update textarea font

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" href="style.css">
     <!-- Link to the external JavaScript files. 'defer' is important! -->
     <script src="templates.js" defer></script>
+    <script src="style-presets.js" defer></script> <!-- Moved earlier -->
     <script src="script.js" defer></script>
-    <script src="style-presets.js" defer></script>
     <script type="module" defer>
         import { polyfillCountryFlagEmojis } from "https://cdn.skypack.dev/country-flag-emoji-polyfill";
         polyfillCountryFlagEmojis();

--- a/style.css
+++ b/style.css
@@ -173,6 +173,7 @@ input[type="text"], input[type="password"], input[type="number"], textarea, sele
 .text-input textarea {
     flex-grow: 1; /* Text input/area takes up available space */
     margin-right: auto; /* Pushes other elements to the right if needed, though gap helps */
+    font-family: "Twemoji Country Flags", Arial, Helvetica;
 }
 
 .text-input .color-input-container {


### PR DESCRIPTION
- Changed script loading order in index.html to fix 'stylePresets is not defined' ReferenceError. `style-presets.js` now loads before `script.js`.
- Applied specific CSS to ensure 'Twemoji Country Flags' font is prioritized for text areas.

This should allow preset galleries to populate correctly and fix related toggle functionality.