### PR TITLE
Fix: Resolve miter spikes in text strokes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1327,6 +1327,7 @@
             if (el.strokeThickness > 0) {
                 ctx.strokeStyle = el.strokeColor;
                 ctx.lineWidth = el.strokeThickness;
+                ctx.lineJoin = 'round'; // Add this to round the corners of strokes
                 drawLines((txt, x, y) => ctx.strokeText(txt, x, y));
             }
             ctx.fillStyle = el.color;


### PR DESCRIPTION
Set canvas context's `lineJoin` property to 'round' before stroking text in `drawTextWithEffect`. This prevents sharp corners from creating long miter spikes, resulting in smoother stroke appearances.