### PR TITLE
UI: Improve styling and text fitting for snippet word choices

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,10 +220,45 @@
                     size: 70, // Keep preview size consistent
                     x: previewCanvas.width / 2,
                     y: previewCanvas.height / 2,
+                    align: 'center',
+                    // Make sure shadow and other properties that affect text width are off for preview sizing
+                    shadowEnabled: false,
+                    strokeThickness: 0
+                };
+
+                // Dynamically adjust font size to fit the word
+                const maxFontSize = 70; // Starting font size
+                const minFontSize = 10; // Minimum font size
+                let fontSize = maxFontSize;
+                pCtx.font = `bold ${fontSize}px ${previewTextElement.fontFamily.includes("Twemoji Country Flags") ? previewTextElement.fontFamily : `"Twemoji Country Flags", ${previewTextElement.fontFamily}`}`;
+                let textWidth = pCtx.measureText(word).width;
+                const padding = 20; // Horizontal padding within the canvas
+
+                while (textWidth > previewCanvas.width - padding && fontSize > minFontSize) {
+                    fontSize -= 2;
+                    pCtx.font = `bold ${fontSize}px ${previewTextElement.fontFamily.includes("Twemoji Country Flags") ? previewTextElement.fontFamily : `"Twemoji Country Flags", ${previewTextElement.fontFamily}`}`;
+                    textWidth = pCtx.measureText(word).width;
+                }
+                previewTextElement.size = fontSize; // Set the adjusted font size
+
+                pCtx.textBaseline = 'middle';
+                // Clear the preview canvas before drawing, in case of redraws or if bg isn't opaque
+                pCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+                // Fill with a background color consistent with the CSS for .snippet-word-preview
+                const isDarkMode = document.body.classList.contains('dark-mode');
+                pCtx.fillStyle = isDarkMode ? '#2a2a2a' : '#555';
+                pCtx.fillRect(0, 0, previewCanvas.width, previewCanvas.height);
+
+                // Use the original preset for drawing, but with the adjusted size and word
+                const finalPreviewElement = {
+                    ...preset, // Original preset for full styling
+                    text: word,
+                    size: fontSize,
+                    x: previewCanvas.width / 2,
+                    y: previewCanvas.height / 2,
                     align: 'center'
                 };
-                pCtx.textBaseline = 'middle';
-                drawTextWithEffect(pCtx, previewTextElement);
+                drawTextWithEffect(pCtx, finalPreviewElement);
             });
 
             document.getElementById('snippet-step1').style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -455,6 +455,35 @@ div[id^="style"] > .text-style-controls input[type="number"] {
             background-color: #2d2d2d;
         }
 
+        /* Styling for snippet word choices to match preset previews */
+        #snippet-word-choices { /* This is the container for snippet-word-preview items */
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+            gap: 8px;
+            padding-top: 10px;
+            padding-bottom: 10px;
+        }
+
+        .snippet-word-preview { /* These are the individual word choice canvases */
+            width: 100%;
+            aspect-ratio: 16 / 9; /* Or adjust if a different aspect ratio is better for words */
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+            background-color: #555; /* Default background for the preview canvas */
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .dark-mode .snippet-word-preview {
+            border-color: #555;
+            background-color: #2a2a2a;
+        }
+        .snippet-word-preview:hover {
+            transform: scale(1.05);
+            box-shadow: 0 0 10px rgba(0, 123, 255, 0.7);
+        }
+
+
 /* Emoji Picker Custom Font */
 emoji-picker {
     --emoji-font-family: "Twemoji Country Flags", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", "EmojiOne Color", "Android Emoji", sans-serif;


### PR DESCRIPTION
This commit addresses UI/UX issues in the 'Add Styled Text' modal's second step (word selection):

1.  **Cursor:** Added `cursor: pointer` CSS rule for `.snippet-word-preview` so the mouse cursor changes to a hand on hover, consistent with other clickable elements.
2.  **Button Styling:** Applied CSS styles to `.snippet-word-preview` and its container `#snippet-word-choices` to match the appearance (background, border, hover effects, grid layout) of the style selection buttons in the modal's first step. The preview canvas background is also now explicitly filled in JavaScript to ensure a solid button appearance.
3.  **Text Clipping:** Implemented dynamic font size adjustment in the `selectSnippetStyle` function. When generating word choice previews, the font size is now reduced iteratively if the text exceeds the canvas width, ensuring words fit within the button boundaries and are not awkwardly cut off. Text is also centered.